### PR TITLE
Upgrade postcss to ^8.4.31

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 'use strict';
 /* eslint-disable */
 

--- a/index.js
+++ b/index.js
@@ -1,7 +1,5 @@
 'use strict';
 
-var postcss = require('postcss');
-var objectAssign = require('object-assign');
 var remRegex = require('./lib/rem-unit-regex');
 var filterPropList = require('./lib/filter-prop-list');
 
@@ -15,11 +13,9 @@ var defaults = {
     minRemValue: 0
 };
 
-module.exports = postcss.plugin('postcss-rem-to-pixel', function (options) {
-
-    var opts = objectAssign({}, defaults, options);
+module.exports = function (options) {
+    var opts = Object.assign({}, defaults, options);
     var remReplace = createRemReplace(opts.rootValue, opts.unitPrecision, opts.minRemValue);
-
     var satisfyPropList = createPropListMatcher(opts.propList);
 
     return function (css) {
@@ -52,7 +48,7 @@ module.exports = postcss.plugin('postcss-rem-to-pixel', function (options) {
         }
 
     };
-});
+};
 
 function createRemReplace (rootValue, unitPrecision, minRemValue) {
     return function (m, $1) {

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "test": "jasmine-node spec"
   },
   "devDependencies": {
-    "jasmine-node": "~1.11.0",
-    "postcss-pxtorem": "^4.0.1"
+    "jasmine-node": "^3.0.0",
+    "postcss-pxtorem": "^6.0.0"
   },
   "keywords": [
     "css",
@@ -26,7 +26,6 @@
     "postcss-plugin"
   ],
   "dependencies": {
-    "object-assign": "^4.1.0",
-    "postcss": "^5.2.10"
+    "postcss": "^8.4.31"
   }
 }


### PR DESCRIPTION
Hello, 👋 

Thanks for the package. Here are some updates to make it work with the latest postcss. This helps get rid of a GitHub vulnerability warning that has been bugging me recently. :)

It should probably be released as a major version bump.

All tests are passing:

```
$ npm run test

> postcss-rem-to-pixel@4.1.2 test
> jasmine-node spec

.............................

Finished in 0.01 seconds
29 tests, 29 assertions, 0 failures, 0 skipped
```

Please let me know if you want me to change anything!
